### PR TITLE
Merging wall gene outer loop implementation

### DIFF
--- a/SharpNeatLib/Utility/MazeUtils.cs
+++ b/SharpNeatLib/Utility/MazeUtils.cs
@@ -401,6 +401,7 @@ namespace SharpNeat.Utility
         public static int DetermineMaxPartitions(MazeGenome mazeGenome)
         {
             int maxPartitions = 0;
+            int loopIter = 0;
 
             // Construct maze grid with solution path generated from connected waypoints
             MazeStructureGridCell[,] mazeGrid = BuildMazeSolutionPath(mazeGenome);
@@ -428,8 +429,6 @@ namespace SharpNeat.Utility
 
                 if (subMaze.AreInternalWallsSupported() && mazeGenome.WallGeneList.Count > 0)
                 {
-                    int loopIter = 0;
-
                     // Queue up the first "room" (which will encompass the entirety of the submaze grid)
                     mazeRoomQueue.Enqueue(subMaze);
 
@@ -442,9 +441,6 @@ namespace SharpNeat.Utility
                                 mazeGenome.WallGeneList[loopIter%mazeGenome.WallGeneList.Count].WallLocation,
                                 mazeGenome.WallGeneList[loopIter%mazeGenome.WallGeneList.Count].PassageLocation,
                                 mazeGenome.WallGeneList[loopIter%mazeGenome.WallGeneList.Count].OrientationSeed);
-
-                        // Update max partitions to the max wall iteration depth in the submaze
-                        maxPartitions = Math.Max(loopIter + 1, maxPartitions);
 
                         if (subRooms != null)
                         {
@@ -459,7 +455,7 @@ namespace SharpNeat.Utility
             }
 
             // Return the maximum number of partitions applied in a submaze
-            return maxPartitions;
+            return loopIter;
         }
 
         /// <summary>

--- a/SharpNeatLib/Utility/MazeUtils.cs
+++ b/SharpNeatLib/Utility/MazeUtils.cs
@@ -473,6 +473,7 @@ namespace SharpNeat.Utility
         {
             List<MazeStructureRoom> mazeRooms = new List<MazeStructureRoom>();
             int partitionCount = 0;
+            int loopIter = 0;
 
             // Extract the "sub-mazes" that are induced by the solution trajectory
             List<MazeStructureRoom> subMazes = ExtractSubmazes(mazeGrid, genome.MazeBoundaryHeight,
@@ -499,9 +500,7 @@ namespace SharpNeat.Utility
                 }
 
                 if (subMaze.AreInternalWallsSupported() && genome.WallGeneList.Count > 0)
-                {
-                    int loopIter = 0;
-
+                {                    
                     // Queue up the first "room" (which will encompass the entirety of the submaze grid)
                     mazeRoomQueue.Enqueue(subMaze);
 

--- a/SharpNeatLibTests/Phenomes/Mazes/MazeStructureRoomTests.cs
+++ b/SharpNeatLibTests/Phenomes/Mazes/MazeStructureRoomTests.cs
@@ -90,7 +90,7 @@ namespace SharpNeat.Phenomes.Mazes.Tests
         [TestMethod]
         public void DivideRoomTest()
         {
-            var baseName = "First_Seed_Maze";
+            var baseName = "32_MutationIter_10_Waypoints_15_Walls_25_Units";
             int mazeHeight = 1;
             int mazeWidth = 1;
             //var seedMazePath = @"F:\User Data\Jonathan\Documents\school\Jonathan\Graduate\PhD\Development\MCC_Projects\MCC_Executor\MazeNavigation\SeedMazes\" + baseName + ".xml";


### PR DESCRIPTION
Previously, each subroom induced by the trajcetory started at the first wall gene in the list, then complexified from that point until the subroom was full. This led to similar looking patches in the maze and under-utilization of wall genes.

This modification loops through wall genes independently, only restarting from the beginning of the wall gene list after it reaches the end of said list, rather than on every subroom.